### PR TITLE
Add workarounds for ayahuasca and herald

### DIFF
--- a/src/main/java/xyz/telosaddon/yuno/features/ShowRangeFeature.java
+++ b/src/main/java/xyz/telosaddon/yuno/features/ShowRangeFeature.java
@@ -60,7 +60,7 @@ public class ShowRangeFeature extends AbstractFeature {
 				// Hacks for specific items
 				switch (itemType) {
 					case UT_HERALD_ESSENCE, EX_HERALD_ESSENCE -> {
-						radius = 8;
+						radius = 6;
 						offset = 3;
 					}
 					case EX_AYAHUASCA_FLASK, UT_AYAHUASCA_FLASK -> radius = 8;

--- a/src/main/java/xyz/telosaddon/yuno/features/ShowRangeFeature.java
+++ b/src/main/java/xyz/telosaddon/yuno/features/ShowRangeFeature.java
@@ -7,9 +7,11 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
+import xyz.telosaddon.yuno.TelosAddon;
 import xyz.telosaddon.yuno.renderer.CircleRenderer;
 import xyz.telosaddon.yuno.renderer.IRenderer;
 import xyz.telosaddon.yuno.renderer.LineRenderer;
+import xyz.telosaddon.yuno.utils.ItemType;
 import xyz.telosaddon.yuno.utils.config.Config;
 
 import java.util.ArrayList;
@@ -51,9 +53,25 @@ public class ShowRangeFeature extends AbstractFeature {
 		if (inventory == null) return;
 		ItemStack itemToCheck = this.itemGetter.apply(inventory);
 		if (!itemToCheck.equals(this.previousItem)) {
+			ItemType itemType = ItemType.fromItemStack(itemToCheck);
 			previousItem = itemToCheck;
-			radius = parseRadius(itemToCheck);
+			float offset = 0;
+			if (itemType == null) radius = parseRadius(itemToCheck);
+			else {
+				// Hacks for specific items
+				switch (itemType) {
+					case UT_HERALD_ESSENCE, EX_HERALD_ESSENCE -> {
+						radius = 8;
+						offset = 3;
+					}
+					case EX_AYAHUASCA_FLASK, UT_AYAHUASCA_FLASK -> radius = 8;
+					default -> radius = parseRadius(itemToCheck);
+
+				}
+			}
 			this.renderers.forEach(r -> r.setRadius(radius));
+			float finalOffset = offset;
+			this.renderers.forEach(r -> r.setOffset(finalOffset));
 		}
 	}
 
@@ -80,7 +98,7 @@ public class ShowRangeFeature extends AbstractFeature {
 	}
 
 	public void setRangeType(RangeViewType type) {
-		this.renderers = switch (type){
+		this.renderers = switch (type) {
 			case CIRCLE -> List.of(new CircleRenderer());
 			case LINE -> List.of(new LineRenderer());
 			case BOTH -> List.of(new CircleRenderer(), new LineRenderer());

--- a/src/main/java/xyz/telosaddon/yuno/renderer/CircleRenderer.java
+++ b/src/main/java/xyz/telosaddon/yuno/renderer/CircleRenderer.java
@@ -22,6 +22,7 @@ public class CircleRenderer implements IRenderer{
 
 
 	private final List<Angle> angles = new ArrayList<>();
+	private float offset = 0;
 
 	@Override
 	public void draw(float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, LivingEntity entity, int color, float height) {
@@ -32,6 +33,7 @@ public class CircleRenderer implements IRenderer{
 		VertexConsumer vertices = vertexConsumers.getBuffer(layer);
 
 		matrices.push();
+		matrices.translate(0, 0, this.offset);
 		drawCircleQuad(matrices, vertices, dy, color);
 		matrices.pop();
 	}
@@ -60,7 +62,7 @@ public class CircleRenderer implements IRenderer{
 
 	@Override
 	public void setOffset(float offset) {
-
+		this.offset = offset;
 	}
 
 	private void clearAngles(){

--- a/src/main/java/xyz/telosaddon/yuno/renderer/CircleRenderer.java
+++ b/src/main/java/xyz/telosaddon/yuno/renderer/CircleRenderer.java
@@ -58,6 +58,11 @@ public class CircleRenderer implements IRenderer{
 			computeAngles(radius);
 	}
 
+	@Override
+	public void setOffset(float offset) {
+
+	}
+
 	private void clearAngles(){
 		angles.clear();
 	}

--- a/src/main/java/xyz/telosaddon/yuno/renderer/CircleRenderer.java
+++ b/src/main/java/xyz/telosaddon/yuno/renderer/CircleRenderer.java
@@ -35,7 +35,18 @@ public class CircleRenderer implements IRenderer{
 		matrices.push();
 		matrices.translate(0, 0, this.offset);
 		drawCircleQuad(matrices, vertices, dy, color);
+		if(this.offset != 0)
+			drawOffsetCenter(matrices, vertices, dy, color);
 		matrices.pop();
+	}
+
+	private void drawOffsetCenter(MatrixStack matrices, VertexConsumer vertices, float dy, int argb){
+		float width = 0.2f;
+		var entry = matrices.peek();
+		vertices.vertex(entry, -width/2, dy, -width/2).color(argb).normal(entry, 0.0f, 0.0f, 0.0f);
+		vertices.vertex(entry, -width/2, dy, width/2).color(argb).normal(entry, 0.0f, 0.0f, 0.0f);;
+		vertices.vertex(entry, width/2, dy, width/2).color(argb).normal(entry, 0.0f, 0.0f, 0.0f);;
+		vertices.vertex(entry, width/2, dy, -width/2).color(argb).normal(entry, 0.0f, 0.0f, 0.0f);;
 	}
 
 	private void drawCircleQuad(MatrixStack matrices, VertexConsumer vertices, float dy, int argb) {

--- a/src/main/java/xyz/telosaddon/yuno/renderer/IRenderer.java
+++ b/src/main/java/xyz/telosaddon/yuno/renderer/IRenderer.java
@@ -14,4 +14,5 @@ public interface IRenderer {
 	 */
 	void setRadius(float radius);
 
+	void setOffset(float offset);
 }

--- a/src/main/java/xyz/telosaddon/yuno/renderer/LineRenderer.java
+++ b/src/main/java/xyz/telosaddon/yuno/renderer/LineRenderer.java
@@ -15,6 +15,7 @@ import java.util.OptionalDouble;
 public class LineRenderer implements IRenderer{
 
 	private float radius = Float.NaN;
+	private float offset = 0;
 
 	@Override
 	public void draw(float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, LivingEntity entity, int color, float height) {
@@ -25,6 +26,7 @@ public class LineRenderer implements IRenderer{
 		VertexConsumer vertices = vertexConsumers.getBuffer(layer);
 
 		matrices.push();
+		matrices.translate(0, 0, offset);
 		drawLine(tickDelta, matrices, vertices, dy, color);
 		matrices.pop();
 	}
@@ -39,8 +41,6 @@ public class LineRenderer implements IRenderer{
 		vertexConsumer.vertex(entry, width/2, dy, this.radius).color(argb).normal(entry, 0.0f, 0.0f, 0);
 		vertexConsumer.vertex(entry, -width/2, dy, this.radius).color(argb).normal(entry, 0.0f, 0.0f, 0);
 		vertexConsumer.vertex(entry, -width/2, dy, 0f).color(argb).normal(entry, 0.0f, 0.0f, 0);
-
-
 	}
 
 	@Override
@@ -50,7 +50,7 @@ public class LineRenderer implements IRenderer{
 
 	@Override
 	public void setOffset(float offset) {
-
+		this.offset = offset;
 	}
 
 	private static class LineRendererPhases extends RenderPhase {

--- a/src/main/java/xyz/telosaddon/yuno/renderer/LineRenderer.java
+++ b/src/main/java/xyz/telosaddon/yuno/renderer/LineRenderer.java
@@ -48,6 +48,11 @@ public class LineRenderer implements IRenderer{
 		this.radius = radius;
 	}
 
+	@Override
+	public void setOffset(float offset) {
+
+	}
+
 	private static class LineRendererPhases extends RenderPhase {
 		static final RenderLayer.MultiPhase LINE_LAYER = makeLayer();
 

--- a/src/main/java/xyz/telosaddon/yuno/utils/ItemType.java
+++ b/src/main/java/xyz/telosaddon/yuno/utils/ItemType.java
@@ -1,0 +1,31 @@
+package xyz.telosaddon.yuno.utils;
+
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import xyz.telosaddon.yuno.TelosAddon;
+
+public enum ItemType {
+
+	UT_HERALD_ESSENCE,
+	EX_HERALD_ESSENCE,
+	NEXUS,
+	UT_AYAHUASCA_FLASK,
+	EX_AYAHUASCA_FLASK;
+
+	public static @Nullable ItemType fromItemStack(ItemStack item){
+		String name = item.getName().getString().trim();
+		String trimmedName = name.substring(1, name.length()-1);
+		if(trimmedName.equals("\uD83E\uDF45"))
+			return UT_HERALD_ESSENCE;
+		if(trimmedName.equals("\uD83E\uDF46"))
+			return EX_HERALD_ESSENCE;
+		if(trimmedName.equals("\uD83F\uDC10"))
+			return NEXUS;
+		if(trimmedName.equals("\uD83E\uDF9D"))
+			return UT_AYAHUASCA_FLASK;
+		if(trimmedName.equals("\uD83E\uDF9C"))
+			return EX_AYAHUASCA_FLASK;
+
+		return null;
+	}
+}


### PR DESCRIPTION
User changes:
- Added workaround for herald's essence, setting the range to 6 and offsetting the start by 3 blocks.
- Added workaround for ayahuasca setting the range to 8

Dev Changes:
- Added an `ItemType` enum, so you can convert an ItemStack to an enum that says what item type it is (rn only done for Nexus, herald and ayahuasca). This is done using unicode check. We should move all of our checks here (esp for autonexus), so we have a nice centralized way to detect which item is which. Rn too lazy to add ALL of the items, but could be done with a script that scans the font files of the texture pack (DM me if you want to know how)

